### PR TITLE
feat(GridButton): allow loading prop be passed to grid button action

### DIFF
--- a/es/components/Grid/GridButtons.js
+++ b/es/components/Grid/GridButtons.js
@@ -16,6 +16,7 @@ export var GridButtons = function GridButtons(_ref) {
       width: "auto",
       key: action.buttonText,
       disabled: action.disabled,
+      loading: action.loading,
       onClick: function onClick(e) {
         e.stopPropagation();
         action.action(item);

--- a/lib/components/Grid/GridButtons.js
+++ b/lib/components/Grid/GridButtons.js
@@ -27,6 +27,7 @@ var GridButtons = function GridButtons(_ref) {
       width: "auto",
       key: action.buttonText,
       disabled: action.disabled,
+      loading: action.loading,
       onClick: function onClick(e) {
         e.stopPropagation();
         action.action(item);

--- a/src/components/Grid/GridButtons.jsx
+++ b/src/components/Grid/GridButtons.jsx
@@ -12,6 +12,7 @@ export const GridButtons = ({ item, actions }) => {
           width='auto'
           key={action.buttonText}
           disabled={action.disabled}
+          loading={action.loading}
           onClick={e => {
             e.stopPropagation()
             action.action(item)


### PR DESCRIPTION
Add a loading option to the grid button to support actions without a modal. 