### PR TITLE
feat(cell): make grid default text truncated

### DIFF
--- a/es/components/Grid/Cell.js
+++ b/es/components/Grid/Cell.js
@@ -22,8 +22,11 @@ import { TruncateGridInfo } from './index';
 import Tooltip from '../Tooltip';
 
 var renderText = function renderText(renderedValue) {
-  return /*#__PURE__*/React.createElement(TruncateGridInfo, null, /*#__PURE__*/React.createElement(Typography, {
+  return /*#__PURE__*/React.createElement(TruncateGridInfo, {
+    minWidth: "0"
+  }, /*#__PURE__*/React.createElement(Typography, {
     variant: "labelSmall",
+    truncate: true,
     color: "textCardTitle"
   }, renderedValue));
 };

--- a/lib/components/Grid/Cell.js
+++ b/lib/components/Grid/Cell.js
@@ -38,8 +38,11 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
 function _objectWithoutPropertiesLoose(source, excluded) { if (source == null) return {}; var target = {}; var sourceKeys = Object.keys(source); var key, i; for (i = 0; i < sourceKeys.length; i++) { key = sourceKeys[i]; if (excluded.indexOf(key) >= 0) continue; target[key] = source[key]; } return target; }
 
 var renderText = function renderText(renderedValue) {
-  return /*#__PURE__*/_react["default"].createElement(_index.TruncateGridInfo, null, /*#__PURE__*/_react["default"].createElement(_etvaskit.Typography, {
+  return /*#__PURE__*/_react["default"].createElement(_index.TruncateGridInfo, {
+    minWidth: "0"
+  }, /*#__PURE__*/_react["default"].createElement(_etvaskit.Typography, {
     variant: "labelSmall",
+    truncate: true,
     color: "textCardTitle"
   }, renderedValue));
 };

--- a/src/components/Grid/Cell.jsx
+++ b/src/components/Grid/Cell.jsx
@@ -14,8 +14,8 @@ import { TruncateGridInfo } from './index'
 import Tooltip from '../Tooltip'
 
 const renderText = renderedValue => (
-  <TruncateGridInfo>
-    <Typography variant='labelSmall' color='textCardTitle'>
+  <TruncateGridInfo minWidth='0'>
+    <Typography variant='labelSmall' truncate color='textCardTitle'>
       {renderedValue}
     </Typography>
   </TruncateGridInfo>

--- a/stories/Grid.stories.jsx
+++ b/stories/Grid.stories.jsx
@@ -80,6 +80,13 @@ const getItems = () => [
     name: 'test 4',
     value: 0,
     description: 'this is a long description'
+  },
+  {
+    id: '3',
+    name: 'this is a super long name and will need to be truncated by the grid',
+    value: 0,
+    description:
+      'this is a super long description and will also need to be truncated by the grid'
   }
 ]
 


### PR DESCRIPTION
https://etvas.atlassian.net/browse/ETV-5739

We need to make every text generated from the `attribute` key truncated by default as we cannot set props without not using the `render` key.