### PR TITLE
fix(tag input): handle blur explicitly

### DIFF
--- a/es/components/TagInput/TagField.js
+++ b/es/components/TagInput/TagField.js
@@ -22,6 +22,7 @@ export var TagField = forwardRef(function (props, ref) {
     exportHandler: exportHandler(props.separator),
     importHandler: importHandler(props.separator),
     onChange: helpers.setValue,
+    onBlur: field.onBlur,
     value: field.value,
     id: id,
     error: displayedError,

--- a/es/components/TagInput/TagInput.js
+++ b/es/components/TagInput/TagInput.js
@@ -1,6 +1,6 @@
 var _templateObject;
 
-var _excluded = ["label", "placeholder", "loading", "required", "disabled", "readOnly", "error", "warning", "valid", "variant", "id", "name", "value", "onChange", "autoComplete", "autoFocus", "onInputClick", "importHandler", "exportHandler", "noPreserveSpace", "forceAddTagKeys", "maxTags"];
+var _excluded = ["label", "placeholder", "loading", "required", "disabled", "readOnly", "error", "warning", "valid", "variant", "id", "name", "value", "onChange", "onBlur", "autoComplete", "autoFocus", "onInputClick", "importHandler", "exportHandler", "noPreserveSpace", "forceAddTagKeys", "maxTags"];
 
 function _taggedTemplateLiteralLoose(strings, raw) { if (!raw) { raw = strings.slice(0); } strings.raw = raw; return strings; }
 
@@ -36,6 +36,7 @@ export var TagInput = forwardRef(function (_ref, ref) {
       name = _ref.name,
       value = _ref.value,
       onChange = _ref.onChange,
+      onBlur = _ref.onBlur,
       autoComplete = _ref.autoComplete,
       autoFocus = _ref.autoFocus,
       onInputClick = _ref.onInputClick,
@@ -91,7 +92,9 @@ export var TagInput = forwardRef(function (_ref, ref) {
     }
   };
 
-  var handleInputBlur = function handleInputBlur() {
+  var handleInputBlur = function handleInputBlur(event) {
+    onBlur(event);
+
     if (inputValue.trim()) {
       handleTagAdd();
     }

--- a/lib/components/TagInput/TagField.js
+++ b/lib/components/TagInput/TagField.js
@@ -39,6 +39,7 @@ var TagField = (0, _react.forwardRef)(function (props, ref) {
     exportHandler: exportHandler(props.separator),
     importHandler: importHandler(props.separator),
     onChange: helpers.setValue,
+    onBlur: field.onBlur,
     value: field.value,
     id: id,
     error: displayedError,

--- a/lib/components/TagInput/TagInput.js
+++ b/lib/components/TagInput/TagInput.js
@@ -31,7 +31,7 @@ var _SubLabel = require("./SubLabel");
 
 var _templateObject;
 
-var _excluded = ["label", "placeholder", "loading", "required", "disabled", "readOnly", "error", "warning", "valid", "variant", "id", "name", "value", "onChange", "autoComplete", "autoFocus", "onInputClick", "importHandler", "exportHandler", "noPreserveSpace", "forceAddTagKeys", "maxTags"];
+var _excluded = ["label", "placeholder", "loading", "required", "disabled", "readOnly", "error", "warning", "valid", "variant", "id", "name", "value", "onChange", "onBlur", "autoComplete", "autoFocus", "onInputClick", "importHandler", "exportHandler", "noPreserveSpace", "forceAddTagKeys", "maxTags"];
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
@@ -60,6 +60,7 @@ var TagInput = (0, _react.forwardRef)(function (_ref, ref) {
       name = _ref.name,
       value = _ref.value,
       onChange = _ref.onChange,
+      onBlur = _ref.onBlur,
       autoComplete = _ref.autoComplete,
       autoFocus = _ref.autoFocus,
       onInputClick = _ref.onInputClick,
@@ -115,7 +116,9 @@ var TagInput = (0, _react.forwardRef)(function (_ref, ref) {
     }
   };
 
-  var handleInputBlur = function handleInputBlur() {
+  var handleInputBlur = function handleInputBlur(event) {
+    onBlur(event);
+
     if (inputValue.trim()) {
       handleTagAdd();
     }

--- a/src/components/TagInput/TagField.jsx
+++ b/src/components/TagInput/TagField.jsx
@@ -21,6 +21,7 @@ export const TagField = forwardRef((props, ref) => {
       exportHandler={exportHandler(props.separator)}
       importHandler={importHandler(props.separator)}
       onChange={helpers.setValue}
+      onBlur={field.onBlur}
       value={field.value}
       id={id}
       error={displayedError}

--- a/src/components/TagInput/TagInput.jsx
+++ b/src/components/TagInput/TagInput.jsx
@@ -30,6 +30,7 @@ export const TagInput = forwardRef(
       name,
       value,
       onChange,
+      onBlur,
       autoComplete,
       autoFocus,
       onInputClick,
@@ -87,7 +88,9 @@ export const TagInput = forwardRef(
       }
     }
 
-    const handleInputBlur = () => {
+    const handleInputBlur = event => {
+      onBlur(event)
+
       if (inputValue.trim()) {
         handleTagAdd()
       }


### PR DESCRIPTION
https://etvas.atlassian.net/browse/ETV-8122

By handling the blur event of the tag input explicitly before updating the tags value, we mark the field as touched manually, so the added tag will trigger an extra validation that will result in the field being valid.